### PR TITLE
Fix for "undefined reference to symbol 'lrint@@GLIBC_2.4'"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,15 @@ INCLUDES+=-I$(SDKSTAGE)/opt/vc/include/ -I$(SDKSTAGE)/opt/vc/include/interface/v
 all: $(BIN) $(LIB)
 
 %.o: %.c
-	@rm -f $@ 
+	@rm -f $@
 	$(CC) $(CFLAGS) $(INCLUDES) -g -c $< -o $@ -Wno-deprecated-declarations
 
 %.o: %.cpp
-	@rm -f $@ 
+	@rm -f $@
 	$(CXX) $(CFLAGS) $(INCLUDES) -g -c $< -o $@ -Wno-deprecated-declarations
 
 %.bin: $(OBJS)
-	$(CC) -o $@ -Wl,--whole-archive $(OBJS) $(LDFLAGS) -Wl,--no-whole-archive -rdynamic
+	$(CC) -o $@ -Wl,--whole-archive $(OBJS) $(LDFLAGS) -Wl,--no-whole-archive -rdynamic -lm
 
 %.a: $(OBJS)
 	$(AR) r $@ $^

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ rpi_osc_video_player
 Video player for Raspberry Pi with perspective correction and OSC control
 Antoine Villeret - 2013
 
-Dependencies : `liblo`, `opencv` and `ilclient` to get the first two, just run : 
+Dependencies : `liblo`, `opencv` and `ilclient` to get the first two, just run :
 
 `$ sudo apt-get install liblo-dev libopencv-dev`
 
@@ -18,7 +18,10 @@ vgfont is not used yet, so it's optional...
 
 to build `rpi_osc_video_player.bin`, just run (in the folder download from git) :
 
-`$ make`
+~~~~
+$ make clean
+$ make
+~~~~
 
 to use :
 


### PR DESCRIPTION
When compiling on Rasbian Jessie got the following error :

```
pi@raspberrypi:~/rpi_osc_video_player $ make clean && make
for i in triangle.o video.o; do (if test -e "$i"; then ( rm $i ); fi );
done
cc `pkg-config --cflags liblo` `pkg-config --cflags opencv` -DSTANDALONE
-D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -DTARGET_POSIX -D_LINUX
-fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
-U_FORTIFY_SOURCE -Wall -g -DHAVE_LIBOPENMAX=2 -DOMX -DOMX_SKIP64BIT
-ftree-vectorize -pipe -DUSE_EXTERNAL_OMX -DHAVE_LIBBCM_HOST
-DUSE_EXTERNAL_LIBBCM_HOST -DUSE_VCHIQ_ARM -Wno-psabi -I/opt/vc/include/
-I/opt/vc/include/interface/vcos/pthreads
-I/opt/vc/include/interface/vmcs_host/linux -I./
-I/opt/vc/src/hello_pi/libs/ilclient -I/opt/vc/src/hello_pi/libs/vgfont
-g -c triangle.c -o triangle.o -Wno-deprecated-declarations
cc `pkg-config --cflags liblo` `pkg-config --cflags opencv` -DSTANDALONE
-D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -DTARGET_POSIX -D_LINUX
-fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
-U_FORTIFY_SOURCE -Wall -g -DHAVE_LIBOPENMAX=2 -DOMX -DOMX_SKIP64BIT
-ftree-vectorize -pipe -DUSE_EXTERNAL_OMX -DHAVE_LIBBCM_HOST
-DUSE_EXTERNAL_LIBBCM_HOST -DUSE_VCHIQ_ARM -Wno-psabi -I/opt/vc/include/
-I/opt/vc/include/interface/vcos/pthreads
-I/opt/vc/include/interface/vmcs_host/linux -I./
-I/opt/vc/src/hello_pi/libs/ilclient -I/opt/vc/src/hello_pi/libs/vgfont
-g -c video.c -o video.o -Wno-deprecated-declarations
cc -o osc_video_player.bin -Wl,--whole-archive triangle.o video.o
-lilclient -llo `pkg-config --libs opencv` -L/opt/vc/lib/ -lGLESv2 -lEGL
-lopenmaxil -lbcm_host -lvcos -lvchiq_arm -lpthread -lrt
-L/opt/vc/src/hello_pi/libs/ilclient -L/opt/vc/src/hello_pi/libs/vgfont
-Wl,--no-whole-archive -rdynamic
/usr/bin/ld: triangle.o: undefined reference to symbol
'lrint@@GLIBC_2.4'
//lib/arm-linux-gnueabihf/libm.so.6: error adding symbols: DSO missing
from command line
collect2: error: ld returned 1 exit status
Makefile:22: recipe for target 'osc_video_player.bin' failed
make: *** [osc_video_player.bin] Error 1
rm video.o triangle.o
```
